### PR TITLE
Don't prettify tag

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -195,7 +195,5 @@ class MarkdownMermaidPlugin(BasePlugin):
             else:
                 js_args =  pyjs.dumps(self.mermaid_args) 
                 new_tag.string="mermaid.initialize(%s);" % js_args
-            # make it look nicer:
-            new_tag = new_tag.prettify()
             soup.body.append(new_tag)
         return str(soup)


### PR DESCRIPTION
Prettifying the tag does not seem to play well with configuration provided in mkdocs.yml, see #17.