### PR TITLE
docs: Auto-configure dark mode feature documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ plugins:
 ```
 
 This works well with the `scheme: preference` option in
-[mkdocs-material](https://squidfunk.github.io/mkdocs-material/).
+[mkdocs-material](https://squidfunk.github.io/mkdocs-material/) and referenced in [their documentation](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-scheme).
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,23 @@ box1[An <b>important</b> <a href="http://google.com">link</a>]
 ```
 
 
+### Auto-configure dark mode based on Host OS
 
+Using a combination of the literal (`^`) functionality of this plugin and the
+[prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+CSS media feature, one can have the plugin automatically enable dark mode.
+
+```yaml
+plugins:
+  - search
+  - mermaid2:
+      arguments:
+          theme: |
+            ^(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light'
+```
+
+This works well with the `scheme: preference` option in
+[mkdocs-material](https://squidfunk.github.io/mkdocs-material/).
 
 ## Compatibility
 


### PR DESCRIPTION
This resolves #23.

Add in documentation about how to configure this plugin for auto-configuring dark mode based on the CSS media feature `prefers-color-scheme`.
