### PR TITLE
Do not parse HTML pages if we know there are no mermaid charts

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -153,6 +153,9 @@ class MarkdownMermaidPlugin(BasePlugin):
         Actions for each page:
         generate the HTML code for all code items marked as 'mermaid'
         """
+        if "mermaid" not in output_content:
+            # Skip unecessary HTML parsing
+            return output_content
         soup = BeautifulSoup(output_content, 'html.parser')
         page_name = page.title
         # first, determine if the page has diagrams:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '0.5.1'
+VERSION = '0.6.0'
 
 def readme():
     """print long description"""


### PR DESCRIPTION
Fix #42.

This optimization should greatly benefit large documentations with limited use of this plugin.
 It does not run `BeautifulSoup` on every pages produced by `mkdocs` and instead checks first for the word `mermaid` textually.
This change allowed a 600 pages documentation (only 1 page with charts) to build in 60s instead of 240s, as about 70% of the total computing time was spent in mermaid's `post_page` event.

This PR should not have any meaningful consequences on the generated files, except for the fact that pages not processed by mermaid will not be reformatted by `bs4` (white lines, indentation and attributes re-ordering). This is probably not an issue since it was mostly a side-effect and actually means keeping the output format of base `mkdocs`.

Three possibilities:
 - Page with charts: no changes in performance or output
 - Pages with the word `mermaid` but no charts: no changes in performance or output, some computing time still "wasted"
 - Pages without the word `mermaid`: much faster processing but output format changed