### PR TITLE
Cache lib url check

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -74,13 +74,14 @@ class MarkdownMermaidPlugin(BasePlugin):
         """
         Provides the actual mermaid library used
         """
-        mermaid_version = self.config['version']
-        lib = self.extra_mermaid_lib or MERMAID_LIB % mermaid_version 
-        if not url_exists(lib):
-            raise FileNotFoundError("Cannot find Mermaid library: %s" %
-                                    lib)
-        return lib
-
+        if not hasattr(self, '_mermaid_lib'):
+            mermaid_version = self.config['version']
+            lib = self.extra_mermaid_lib or MERMAID_LIB % mermaid_version 
+            if not url_exists(lib):
+                raise FileNotFoundError("Cannot find Mermaid library: %s" %
+                                        lib)
+            self._mermaid_lib = lib
+        return self._mermaid_lib
 
     @property
     def activate_custom_loader(self) -> bool:


### PR DESCRIPTION
This pull request adds a simple cache to the `mermaid_lib` property. The reason is that for projects with many pages the url check with `url_exists(...)` is done redundantly. It decreased the build time for my setup significantly.

Python 3.8 has a  `cached_property` decorator in functools but I guess that is probably not the minimal Python version you want to support. I could use `functools.lru_cache` if you prefer, though.

edit: Fixes #44.