### PR TITLE
README: Fix snippet for dark mode switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ plugins:
       arguments:
         # test if its __palette_1 (dark) or __palette_2 (light)
         theme: |
-          ^(JSON.parse(window.localStorage.getItem('/.__palette')).index == 1) ? 'dark' : 'light'
+          ^(JSON.parse(window.localStorage.getItem(__prefix('__palette'))).index == 1) ? 'dark' : 'light'
 
 extra_javascript:
     - extra/refresh_on_toggle_dark_light.js


### PR DESCRIPTION
The hardcoded `localStorage` key does not work when the page is read through `file://` - in that case the key is prefixed with the full file path (see [index.ts](https://github.com/squidfunk/mkdocs-material/blob/f4b1f97dd078fca380bca7c4c44a4f26c2f2cbb8/src/assets/javascripts/components/palette/index.ts#L106) and [base.html](https://github.com/squidfunk/mkdocs-material/blob/f4b1f97dd078fca380bca7c4c44a4f26c2f2cbb8/src/partials/javascripts/base.html#L30)). To find the proper key, we also have to use the prefix function here.