### PR TITLE
Use latest version of mermaid.js

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -16,7 +16,7 @@ from .util import info, libname, url_exists
 # Constants and utilities
 # ------------------------
 # the default (recommended) mermaid lib
-MERMAID_LIB_VERSION = '8.8.0'
+MERMAID_LIB_VERSION = '9.3.0'
 MERMAID_LIB = "https://unpkg.com/mermaid@%s/dist/mermaid.min.js"
 # Two conditions for activating custom fences:
 SUPERFENCES_EXTENSION = 'pymdownx.superfences'


### PR DESCRIPTION
mermaid.js 8.8.0 does not seem to work with ER Diagrams

This PR bumps to the latest version.

Context:

I am part of the team that developers the [LinkML](https://linkml.io/linkml) modeling framework. We ❤️ mermaid! We have lots of schemas rolled out that use UML class diagrams.

We recently made a release that allows for use of ER diagrams:

https://github.com/linkml/linkml/releases/tag/v1.4.1

In order to deploy this, each individual site has to update their mkdocs.yml to configure to use the latest version. It would be awesome if there was a new release of this plugin, allowing us to use the default config!

Many thanks for your work!