### PR TITLE
Add support for loading mermaid via esm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You may specify a different version of the Mermaid library, like so:
 plugins:
   - search
   - mermaid2:
-      version: 8.6.4
+      version: 10.0.2
 ```
 
 


### PR DESCRIPTION
Fixes #70 

## Changes

- Bump default mermaid version to 10.0.2
- Add support for loading mermaid via an ESM module when requested mermaid version is >= 10
- **Breaking Change**: Loading mermaid directly through `extra_javascript` is no longer possible for version >= 10. This probably requires readme changes not included in this PR. It may be possible for users to include a simple JS file that imports mermaid via esm here instead.

## Context

From mermaid v10 onwards mermaid is only distributed as an ESM module. See [Mermaid #3590](https://github.com/mermaid-js/mermaid/issues/3590) for discussion on this change.

Users will probably notice this problem if they are following the readme recommended way of loading the latest version of mermaid through `extra_javascript` as including `https://unpkg.com/mermaid/dist/mermaid.min.js` resolves to e.g `https://unpkg.com/mermaid@10.0.2/dist/mermaid.min.js` which does not exist. 

Looking around other projects this seems to be a common issue for libraries including mermaid. 

To resolve this mermaid must now be explicitly imported through e.g

```html
<script type="module">
import mermaid from "https://unpkg.com/mermaid@10.0.2/dist/mermaid.esm.min.mjs"
mermaid.initialize()
</script>
```

To achieve this this PR makes several changes:

- Bump default mermaid version to 10.0.2 (latest at time of writing)
- Split mermaid lib locations constants into pre and post 10 version to account for difference in locations
- Wrap mermaid lib info in a small value object that also tracks mermaid style (js or esm)
- Change resolution of mermaid location to make use of the above
- Change mermaid loader to user `<script src="...">` or `<script type="module">` as appropriate. 
