### PR TITLE
Fix extra_javascript config reading for mkdocs 1.5.0

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -96,7 +96,7 @@ class MarkdownMermaidPlugin(BasePlugin):
         """
         Provides the mermaid library defined in mkdocs.yml (if any)
         """
-        extra_javascript = self.full_config.get('extra_javascript', [])
+        extra_javascript = map(str, self.full_config.get('extra_javascript', []))
         for lib in extra_javascript:
             # get the actual library name
             if  libname(lib) == 'mermaid':

--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -96,6 +96,7 @@ class MarkdownMermaidPlugin(BasePlugin):
         """
         Provides the mermaid library defined in mkdocs.yml (if any)
         """
+        # as of mkdocs 1.5, extra_javascript is a list of objects; convert to string
         extra_javascript = map(str, self.full_config.get('extra_javascript', []))
         for lib in extra_javascript:
             # get the actual library name


### PR DESCRIPTION
mkdocs 1.5.0 now returns extra_javascript config options as an object