### PR TITLE
 Unhandled exception when checking if URL exists #101 

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -42,6 +42,7 @@ class MarkdownMermaidPlugin(BasePlugin):
 
         ('version', PluginType(str, default=JAVASCRIPT_VERSION)),
         ('javascript', PluginType(str, default=None)),
+        ('allow_inaccessible_url', PluginType(bool, default=False)),
         ('arguments', PluginType(dict, default={})),
         # ('custom_loader', PluginType(bool, default=False))
     )
@@ -142,8 +143,9 @@ class MarkdownMermaidPlugin(BasePlugin):
                               local_base_dir=self.full_config['docs_dir']):
                 critical("Cannot find Mermaid library: %s" %
                                         javascript)
-                raise FileNotFoundError("Cannot find Mermaid library: %s" %
-                                        javascript)
+                if not self.config['allow_inaccessible_url']:
+                    raise FileNotFoundError("Cannot find Mermaid library: %s" %
+                                        javascript)     
             self._javascript = javascript
         return self._javascript
     

--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -10,7 +10,7 @@ from mkdocs.config.config_options import Type as PluginType
 from bs4 import BeautifulSoup
 
 from . import pyjs
-from .util import info, libname, url_exists
+from .util import info, libname, url_exists, critical
 
 
 # ------------------------
@@ -140,6 +140,8 @@ class MarkdownMermaidPlugin(BasePlugin):
                 # make checks
             if not url_exists(javascript, 
                               local_base_dir=self.full_config['docs_dir']):
+                critical("Cannot find Mermaid library: %s" %
+                                        javascript)
                 raise FileNotFoundError("Cannot find Mermaid library: %s" %
                                         javascript)
             self._javascript = javascript

--- a/mermaid2/util.py
+++ b/mermaid2/util.py
@@ -27,7 +27,19 @@ def info(*args) -> str:
     args = [MERMAID_LABEL] + [str(arg) for arg in args]
     msg = ' '.join(args)
     log.info(msg)
- 
+
+def warning(*args) -> str:
+    "Write information on the console, preceded by the signature label"
+    args = [MERMAID_LABEL] + [str(arg) for arg in args]
+    msg = ' '.join(args)
+    log.warning(msg)
+
+def critical(*args) -> str:
+    "Write information on the console, preceded by the signature label"
+    args = [MERMAID_LABEL] + [str(arg) for arg in args]
+    msg = ' '.join(args)
+    log.critical(msg)
+
 # -------------------
 # Paths and URLs
 # -------------------
@@ -45,8 +57,20 @@ def libname(lib:str) -> str:
 def url_exists(url:str, local_base_dir:str='') -> bool:
     "Checks that a url exists"
     if url.startswith('http'):
-        request = requests.get(url)
-        return request.status_code == 200
+        # requests can fail without HTTP code, list:
+        # https://docs.python-requests.org/en/latest/_modules/requests/exceptions/
+        try:
+            request = requests.get(url)
+        except Exception as ue:
+            if ue.__class__.__module__ == "requests.exceptions":
+                warning("Exception when making a GET request: %s" % ue)
+                return False
+            # Returning the rest
+            else:
+                raise
+        else:
+            return request.status_code == 200
+        
     else:
         pathname = os.path.join(local_base_dir, url)
         return os.path.exists(pathname)


### PR DESCRIPTION
Handle exceptions raised from the use of `requests.exceptions`.
Implement warning and critical in the style of the original authors:
Warning is used for capturing the faulty request.
Critical is used to notify user that there is a problem.

I am still leaving the raise FileNotFoundError there as I wanted to make another request for turning this optional.