### PR TITLE
Set version of setuptools dependency to be less than 72

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license='MIT',
     python_requires='>=3.6',
     install_requires=[
-        'setuptools>=18.5',
+        'setuptools>=18.5, <72',
         'beautifulsoup4>=4.6.3',
         'mkdocs>=1.0.4',
         'jsbeautifier',


### PR DESCRIPTION
Setup tools has a breaking version which is causing issues. https://setuptools.pypa.io/en/stable/history.html#v72-0-0

This PR is just to lock the version to be before 72.0.0. A future PR may be needed to migrate to a different test runner.