### PR TITLE
bug: fixing replaceWith depreciation

### DIFF
--- a/mermaid2/plugin.py
+++ b/mermaid2/plugin.py
@@ -254,7 +254,7 @@ class MarkdownMermaidPlugin(BasePlugin):
                     new_tag = soup.new_tag("div", attrs={"class": "mermaid"})
                     new_tag.append(content)
                     # replace the parent:
-                    tag.parent.replaceWith(new_tag)
+                    tag.parent.replace_with(new_tag)
             # Count the diagrams <div class = 'mermaid'> ... </div>
             mermaids = len(soup.select("div.mermaid"))
         # if yes, add the javascript snippets:


### PR DESCRIPTION
# Fix BeautifulSoup replaceWith deprecation warning

please refer to #118 for more information

## Description
Fixes the deprecation warning:
```
DeprecationWarning: Call to deprecated method replaceWith. (Replaced by replace_with) -- Deprecated since version 4.0.0.
```

## Changes
- Replace `replaceWith()` with `replace_with()` in `mermaid2/plugin.py`

## Files changed
- `mermaid2/plugin.py`
